### PR TITLE
Feature code listing and reference

### DIFF
--- a/chapters/chap2_examples.tex
+++ b/chapters/chap2_examples.tex
@@ -110,6 +110,7 @@ Mit dem Compiler \textit{pdfLaTeX} ist es möglich andere PDF-Dokumente wie ein 
 \section{Quellcode}
 Quellcode kann als Block oder im Fließtext stehen. Der Ausdruck \mintinline{python}{print(x**2)} ist ein Beispiel für Inline-Quelltext.
 
+Folgender Code-Block taucht nicht im Code-Verzeichnis auf:
 \begin{minted}{json}
 {   
     "id" : 1234,  
@@ -117,6 +118,17 @@ Quellcode kann als Block oder im Fließtext stehen. Der Ausdruck \mintinline{pyt
     "field2" : "welt"
 }
 \end{minted}
+
+Folgender Code-Block taucht im Code-Verzeichnis auf:
+\begin{code}{json}{Eine tolle Unterschrift von einem JSON-Codeblock}{code:json-label}
+{   
+    "id" : 1234,
+    "field1": "hallo",
+    "field2" : "welt"
+}
+\end{code}
+
+Codeblöcke können mit \mintinline{latex}{\ref{<labelname>}} referenziert werden, ungefähr so: \ref{code:json-label}.
 
 %% ---------------------------------------------
 %% Referenzen

--- a/chapters/chap2_examples.tex
+++ b/chapters/chap2_examples.tex
@@ -119,7 +119,7 @@ Folgender Code-Block taucht nicht im Code-Verzeichnis auf:
 }
 \end{minted}
 
-Folgender Code-Block taucht im Code-Verzeichnis auf:
+Folgender Code-Block taucht im Code-Verzeichnis auf: \\
 \begin{code}{json}{Eine tolle Unterschrift von einem JSON-Codeblock}{code:json-label}
 {   
     "id" : 1234,

--- a/main.tex
+++ b/main.tex
@@ -125,6 +125,12 @@
 %% Tabellenverzeichnis
 \listoftables
 
+%% Code-Verzeichnis wenn Code-Blöcke irgendwo auftauchen
+\renewcommand\lstlistlistingname{Code-Verzeichnis} %Code-Verzeichnis
+\iftotallstlistings
+    \lstlistoflistings
+\fi
+
 %% Marks main part using arabic page numbers and such; Only available in scrbook
 \mainmatter
 

--- a/main.tex
+++ b/main.tex
@@ -119,15 +119,23 @@
 \input{etc/acronyms}
 
 %% Abbildungsverzeichnis
-\addtocontents{lof}{\protect\addcontentsline{toc}{chapter}{\listfigurename}}
+\cleardoublepage
+\phantomsection
+\addcontentsline{toc}{chapter}{\listfigurename}
 \listoffigures
 
 %% Tabellenverzeichnis
+\cleardoublepage
+\phantomsection
+\addcontentsline{toc}{chapter}{\listtablename}
 \listoftables
 
 %% Code-Verzeichnis wenn Code-Blöcke irgendwo auftauchen
 \renewcommand\lstlistlistingname{Code-Verzeichnis} %Code-Verzeichnis
 \iftotallstlistings
+    \cleardoublepage
+    \phantomsection
+    \addcontentsline{toc}{chapter}{\lstlistlistingname}
     \lstlistoflistings
 \fi
 

--- a/template/preamble.tex
+++ b/template/preamble.tex
@@ -152,3 +152,34 @@ BCOR=\myBCOR,       %% binding correction (depends on how you bind the resulting
 \AtBeginEnvironment{minted}{\dontdofcolorbox}
 \def\dontdofcolorbox{\renewcommand\fcolorbox[4][]{##4}}
 \makeatother
+
+%% for the code-block environment with listing and reference possibility:
+%% \begin{code}{<language>}{<caption>}{<label>} 
+%% ... 
+%% \end{code}
+%% is also used with listings so there is a list of code blocks
+\usepackage{listings}
+\usepackage[lstlisting]{totalcount}
+\renewcommand{\lstlistingname}{Code}
+\usepackage{caption}
+\captionsetup[lstlisting]{skip=5pt,belowskip=15pt} %spacing for the label
+%% the following see also here: https://github.com/gpoore/minted/issues/108
+\newcommand{\storeCaption}{}
+\newcommand{\storeLabel}{}
+\newenvironment{codelisting}{\captionsetup{type=lstlisting}}{}
+\newenvironment{code}[3]
+{%
+	\VerbatimEnvironment
+	\renewcommand{\storeCaption}{#2}%
+	\renewcommand{\storeLabel}{#3}%
+	\begin{minipage}{\linewidth}%
+	\begin{codelisting}%
+	\begin{minted}{#1}%
+	}
+	{%
+	\end{minted}%
+	\caption{\storeCaption}%
+	\label{\storeLabel}%
+	\end{codelisting}%
+	\end{minipage}\\%
+}


### PR DESCRIPTION
adds a new `\begin{code}` environment that is capable of adding a caption to the code block, adding a listing to the beginning of the document and can be referenced in the text with `\ref{<label>}`