### PR TITLE
changed fontsize of \mintinline command in caption of code block

### DIFF
--- a/template/preamble.tex
+++ b/template/preamble.tex
@@ -178,7 +178,12 @@ BCOR=\myBCOR,       %% binding correction (depends on how you bind the resulting
 	}
 	{%
 	\end{minted}%
-	\caption{\storeCaption}%
+	\caption{%
+	    {
+	    \setmintedinline{fontsize=\footnotesize}%
+	    \storeCaption %
+	    }%
+    	}%
 	\label{\storeLabel}%
 	\end{codelisting}%
 	\end{minipage}%


### PR DESCRIPTION
I noticed that the font size of `\mintinline` inside a caption underneath a `\begin{code}`-block is bigger compared to the regular font size of a caption. It is subtle but once you notice it, you can't unsee it...
![grafik](https://user-images.githubusercontent.com/25104859/124468412-5920f900-dd99-11eb-9145-aa3f194601f0.png)

I fixed it by changing the font size of `\mintinline` inside the `code` environment defintion to `\footnotesize`.
After that it looks like this:
![grafik](https://user-images.githubusercontent.com/25104859/124468631-9eddc180-dd99-11eb-8999-1d58cdd15bd4.png)


Now this problem also appears in captions underneath figures... This quick fix only fixes this in captions underneath `code` blocks and I thought it is way more common to place a `\mintinline` in the caption of a `code` block rather than underneath a figure.